### PR TITLE
refactor(lsp): remove redundant client cleanup (#18744)

### DIFF
--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -1188,12 +1188,6 @@ function lsp.start_client(config)
   ---
   ---@param force (bool, optional)
   function client.stop(force)
-    lsp.diagnostic.reset(client_id, all_buffer_active_clients)
-    changetracking.reset(client_id)
-    for _, client_ids in pairs(all_buffer_active_clients) do
-      client_ids[client_id] = nil
-    end
-
     local handle = rpc.handle
     if handle:is_closing() then
       return


### PR DESCRIPTION
The client state is cleaned up both in client.stop() as well as in the client.on_exit() handler. Technically, the client has not actually stopped until the on_exit handler is called, so we should just do this cleanup there and remove it from client.stop().